### PR TITLE
Use INT_MAX as persistent count

### DIFF
--- a/test.c
+++ b/test.c
@@ -9,7 +9,7 @@ main(void) {
   #ifdef __AFL_HAVE_MANUAL_CONTROL
     __AFL_INIT();
   #endif
-    while (__AFL_LOOP(100000)) {
+    while (__AFL_LOOP(4294967296)) {
     }
 #endif
 


### PR DESCRIPTION
100000 as persistent count means that it is still forking every 100000 executions, that is a comparable time to fork i guess, so it is better to use INT_MAX (cannot disable fork at all for AFL++).

Btw, using this program as a bench does not really make sense, the bottleneck is the fuzzer and the pipe used to communicate the request for a new execution, which should be a negligible overhead on real programs. Maybe worth a try using an existing libfuzzer harness on a relatively small library to test, like pcre2 or similar?